### PR TITLE
カラーテーマをブルー・シアン系に統一し、デザインの一貫性を向上

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -15,7 +15,8 @@
       "Bash(grep:*)",
       "Bash(cp:*)",
       "Bash(git checkout:*)",
-      "Bash(gh pr create:*)"
+      "Bash(gh pr create:*)",
+      "Bash(node:*)"
     ],
     "deny": []
   }

--- a/src/components/common/CTAButton.tsx
+++ b/src/components/common/CTAButton.tsx
@@ -10,8 +10,18 @@ interface CTAButtonProps {
 export default function CTAButton({ button, size = "default", className = "" }: CTAButtonProps) {
   const baseClasses = "font-bold rounded-full transform hover:scale-105 transition-all duration-200 h-auto";
   const variantClasses = {
-    primary: "bg-blue-600 hover:bg-blue-700 text-white shadow-lg",
-    secondary: "bg-white text-orange-600 hover:bg-gray-100"
+    primary: "text-white shadow-lg hover:scale-105 transition-all duration-200",
+    secondary: "bg-white shadow-lg border-2 hover:scale-105 transition-all duration-200"
+  };
+
+  const primaryStyle = {
+    backgroundColor: 'var(--orange-9)',
+    '--tw-shadow': '0 10px 15px -3px rgb(0 0 0 / 0.1), 0 4px 6px -4px rgb(0 0 0 / 0.1)'
+  };
+
+  const secondaryStyle = {
+    color: 'var(--orange-9)',
+    borderColor: 'var(--orange-9)'
   };
 
   const sizeClasses = {
@@ -20,11 +30,15 @@ export default function CTAButton({ button, size = "default", className = "" }: 
     lg: "px-12 py-5 text-xl"
   };
 
+  const variant = button.variant || 'primary';
+  const buttonStyle = variant === 'primary' ? primaryStyle : secondaryStyle;
+
   return (
     <Button
       asChild
       size={size}
-      className={`${baseClasses} ${variantClasses[button.variant || 'primary']} ${sizeClasses[size]} ${className}`}
+      className={`${baseClasses} ${variantClasses[variant]} ${sizeClasses[size]} ${className}`}
+      style={buttonStyle}
     >
       <a
         href={button.href}

--- a/src/components/common/TeamMemberCard.tsx
+++ b/src/components/common/TeamMemberCard.tsx
@@ -10,10 +10,10 @@ interface TeamMemberCardProps {
 export default function TeamMemberCard({ member, className = "" }: TeamMemberCardProps) {
   const colorClasses = {
     orange: {
-      bg: "from-orange-400 to-red-500",
-      border: "border-orange-400",
-      text: "text-orange-500",
-      badgeBg: "bg-orange-500 hover:bg-orange-600"
+      bg: "from-blue-400 to-indigo-500",
+      border: "border-blue-400",
+      text: "text-blue-500",
+      badgeBg: "bg-blue-500 hover:bg-blue-600"
     },
     blue: {
       bg: "from-blue-400 to-indigo-500", 
@@ -34,10 +34,10 @@ export default function TeamMemberCard({ member, className = "" }: TeamMemberCar
       badgeBg: "bg-green-500 hover:bg-green-600"
     },
     yellow: {
-      bg: "from-yellow-400 to-orange-500",
-      border: "border-yellow-400",
-      text: "text-yellow-500",
-      badgeBg: "bg-yellow-500 hover:bg-yellow-600"
+      bg: "from-cyan-400 to-blue-500",
+      border: "border-cyan-400",
+      text: "text-cyan-500",
+      badgeBg: "bg-cyan-500 hover:bg-cyan-600"
     }
   };
 

--- a/src/components/sections/ConceptSection.tsx
+++ b/src/components/sections/ConceptSection.tsx
@@ -7,12 +7,12 @@ interface ConceptSectionProps {
 
 export default function ConceptSection({ data }: ConceptSectionProps) {
   return (
-    <section className="py-16 bg-gradient-to-b from-blue-50 to-green-50">
+    <section className="py-16 bg-gradient-to-b from-[#f0f9fa] to-green-50">
       <div className="container mx-auto px-4">
         {/* メインコンセプト */}
         <div className="text-center mb-16">
           <h2 className="text-3xl md:text-4xl font-bold text-gray-800 mb-6">
-            <span className="text-blue-600">{data.title}</span>
+            <span className="text-[#6cb7c7]">{data.title}</span>
           </h2>
           <p className="text-lg text-gray-600 max-w-3xl mx-auto leading-relaxed mb-8 whitespace-pre-line">
             {data.description}

--- a/src/components/sections/ExperienceSection.tsx
+++ b/src/components/sections/ExperienceSection.tsx
@@ -22,10 +22,10 @@ export default function ExperienceSection({ data }: ExperienceSectionProps) {
 
         {/* LED信号機プログラミング体験 */}
         <div className="mb-16">
-          <Card className="bg-gradient-to-r from-orange-50 to-yellow-50 border-orange-200">
+          <Card className="bg-gradient-to-r from-[#f0f9fa] to-[#f0f9fa] border-[#a8dee9]">
             <CardContent className="p-8">
               <div className="text-center mb-8">
-                <Badge className={`bg-${data.badge.variant}-500 hover:bg-${data.badge.variant}-600 mb-4`}>
+                <Badge className="bg-[#6cb7c7] hover:bg-[#5aa3b5] mb-4">
                   {data.badge.text}
                 </Badge>
                 <CardTitle className="text-2xl mb-4">

--- a/src/components/sections/HeroSection.tsx
+++ b/src/components/sections/HeroSection.tsx
@@ -8,7 +8,7 @@ interface HeroSectionProps {
 
 export default function HeroSection({ data }: HeroSectionProps) {
   return (
-    <section className="min-h-screen bg-gradient-to-br from-orange-400 via-yellow-400 to-orange-300 relative overflow-hidden">
+    <section className="min-h-screen bg-gradient-to-br from-[#a8dee9] via-[#bfe4ec] to-[#91d5e0] relative overflow-hidden">
       <div className="container mx-auto px-4 py-16 flex flex-col items-center justify-center min-h-screen text-center">
         {/* メインキャッチコピー */}
         <div className="mb-8">
@@ -18,7 +18,7 @@ export default function HeroSection({ data }: HeroSectionProps) {
           <h2 className="text-3xl md:text-5xl font-bold text-gray-800 mb-6">
             {data.subtitle}
           </h2>
-          <p className="text-xl md:text-2xl text-gray-700 font-medium">
+          <p className="text-xl md:text-2xl text-slate-700 font-medium">
             {data.description}
           </p>
         </div>
@@ -61,28 +61,31 @@ export default function HeroSection({ data }: HeroSectionProps) {
         {data.catchCopy && (
           <div className="mb-8 w-full max-w-4xl relative">
             {/* 温かい光沢エフェクト */}
-            <div className="absolute inset-0 bg-gradient-to-r from-orange-200/40 via-yellow-200/40 to-orange-200/40 rounded-2xl blur-lg"></div>
+            <div className="absolute inset-0 bg-gradient-to-r from-[#a8dee9]/40 via-[#bfe4ec]/40 to-[#a8dee9]/40 rounded-2xl blur-lg"></div>
             
             {/* メインコンテナ */}
-            <div className="relative bg-gradient-to-r from-white/95 via-yellow-50/95 to-white/95 backdrop-blur-sm p-8 rounded-2xl shadow-2xl border border-orange-200/50 transform hover:scale-102 transition-all duration-300">
+            <div className="relative bg-gradient-to-r from-white/95 via-[#a8dee9]/20 to-white/95 backdrop-blur-sm p-8 rounded-2xl shadow-2xl border border-[#a8dee9]/50 transform hover:scale-102 transition-all duration-300">
               
               {/* 上部装飾ライン */}
-              <div className="absolute top-0 left-0 w-full h-1 bg-gradient-to-r from-orange-400 via-yellow-400 to-orange-400 rounded-t-2xl"></div>
+              <div className="absolute top-0 left-0 w-full h-1 bg-gradient-to-r from-[#a8dee9] via-[#bfe4ec] to-[#a8dee9] rounded-t-2xl"></div>
               
               {/* 装飾的な要素（控えめ） */}
-              <div className="absolute -top-2 left-8 w-4 h-4 bg-yellow-400 rounded-full shadow-lg opacity-80"></div>
-              <div className="absolute -top-1 right-12 w-3 h-3 bg-orange-400 rounded-full shadow-lg opacity-70"></div>
-              <div className="absolute -bottom-2 left-16 w-3 h-3 bg-red-400 rounded-full shadow-lg opacity-60"></div>
-              <div className="absolute -bottom-1 right-8 w-2 h-2 bg-yellow-500 rounded-full shadow-lg opacity-80"></div>
+              <div className="absolute -top-2 left-8 w-4 h-4 bg-[#a8dee9] rounded-full shadow-lg opacity-80"></div>
+              <div className="absolute -top-1 right-12 w-3 h-3 bg-[#91d5e0] rounded-full shadow-lg opacity-70"></div>
+              <div className="absolute -bottom-2 left-16 w-3 h-3 bg-[#bfe4ec] rounded-full shadow-lg opacity-60"></div>
+              <div className="absolute -bottom-1 right-8 w-2 h-2 bg-[#a8dee9] rounded-full shadow-lg opacity-80"></div>
               
               {/* キャッチコピー内容 */}
               <div className="relative z-10 text-center">
                 {/* メインメッセージ */}
                 <div className="mb-4">
                   <p className="text-2xl md:text-3xl lg:text-4xl font-bold text-gray-800 leading-tight">
-                    <span className="inline-block bg-gradient-to-r from-orange-600 to-red-500 bg-clip-text text-transparent">自由研究提出OK</span>
-                    <span className="inline-block mx-3 text-3xl md:text-4xl text-yellow-600 animate-bounce">→</span>
-                    <span className="inline-block bg-gradient-to-r from-blue-600 to-purple-600 bg-clip-text text-transparent">将来のスキルまで！</span>
+                    <span className="inline-block bg-gradient-to-r from-[#6cb7c7] to-[#5aa3b5] bg-clip-text text-transparent">自由研究提出OK</span>
+                    <span 
+                      className="inline-block mx-3 text-3xl md:text-4xl animate-bounce"
+                      style={{ color: 'var(--orange-9)' }}
+                    >→</span>
+                    <span className="inline-block bg-gradient-to-r from-[#6cb7c7] to-[#7bbfce] bg-clip-text text-transparent">将来のスキルまで！</span>
                   </p>
                 </div>
                 
@@ -92,9 +95,9 @@ export default function HeroSection({ data }: HeroSectionProps) {
                   <div className="absolute inset-0 bg-gray-400/30 transform translate-x-1 translate-y-1 blur-sm"></div>
                   
                   {/* 付箋本体 */}
-                  <div className="relative bg-yellow-200 px-6 py-4 shadow-lg transform -rotate-2 hover:-rotate-1 transition-transform duration-300 border-l-2 border-yellow-400">
+                  <div className="relative bg-[#bfe4ec] px-6 py-4 shadow-lg transform -rotate-2 hover:-rotate-1 transition-transform duration-300 border-l-2 border-[#a8dee9]">
                     {/* 付箋の角がめくれた効果 */}
-                    <div className="absolute -top-1 -right-1 w-4 h-4 bg-yellow-100 transform rotate-45 shadow-sm"></div>
+                    <div className="absolute -top-1 -right-1 w-4 h-4 bg-[#d4ebef] transform rotate-45 shadow-sm"></div>
                     <div className="absolute -top-0.5 -right-0.5 w-3 h-3 bg-white/50 transform rotate-45"></div>
                     
                     {/* テキスト */}
@@ -103,13 +106,13 @@ export default function HeroSection({ data }: HeroSectionProps) {
                     </p>
                     
                     {/* 付箋の質感 */}
-                    <div className="absolute inset-0 bg-gradient-to-br from-yellow-100/30 to-transparent pointer-events-none"></div>
+                    <div className="absolute inset-0 bg-gradient-to-br from-[#d4ebef]/30 to-transparent pointer-events-none"></div>
                   </div>
                 </div>
               </div>
               
               {/* 下部装飾ライン */}
-              <div className="absolute bottom-0 left-0 w-full h-1 bg-gradient-to-r from-orange-400 via-yellow-400 to-orange-400 rounded-b-2xl"></div>
+              <div className="absolute bottom-0 left-0 w-full h-1 bg-gradient-to-r from-[#a8dee9] via-[#bfe4ec] to-[#a8dee9] rounded-b-2xl"></div>
             </div>
             
             {/* サイドの装飾 */}
@@ -132,11 +135,11 @@ export default function HeroSection({ data }: HeroSectionProps) {
               <p className="text-gray-700 text-lg">{data.eventInfo.dates}</p>
             </CardContent>
           </Card>
-          <Card className="bg-gradient-to-br from-red-500 to-pink-500 backdrop-blur-sm border-2 border-yellow-300 shadow-2xl transform hover:scale-105 transition-all duration-300">
+          <Card className="bg-gradient-to-br from-orange-400 to-orange-600 backdrop-blur-sm border-2 border-orange-300 shadow-2xl transform hover:scale-105 transition-all duration-300">
             <CardContent className="p-6 text-center">
               <div className="text-4xl mb-3 animate-bounce">🏪</div>
               <h3 className="font-bold text-white mb-2 text-lg">ブース番号</h3>
-              <p className="font-extrabold text-4xl drop-shadow-lg bg-yellow-400 text-white px-4 py-2 rounded-full inline-block border-4 border-white">
+              <p className="font-extrabold text-4xl drop-shadow-lg bg-[#6cb7c7] text-white px-4 py-2 rounded-full inline-block border-4 border-[#a8dee9]">
                 {data.eventInfo.boothNumber}
               </p>
             </CardContent>

--- a/src/components/sections/PricingSection.tsx
+++ b/src/components/sections/PricingSection.tsx
@@ -11,7 +11,7 @@ interface PricingSectionProps {
 
 export default function PricingSection({ data }: PricingSectionProps) {
   return (
-    <section className="py-16 bg-gradient-to-br from-orange-400 via-yellow-400 to-orange-300">
+    <section className="py-16 bg-gradient-to-br from-[#a8dee9] via-[#bfe4ec] to-[#91d5e0]">
       <div className="container mx-auto px-4">
         {/* 料金体系 */}
         <div className="text-center mb-16">
@@ -27,7 +27,10 @@ export default function PricingSection({ data }: PricingSectionProps) {
           {/* 無料サービス */}
           <Card className="shadow-2xl flex flex-col h-full">
             <CardHeader className="text-center pb-4">
-              <Badge className="bg-green-500 hover:bg-green-600 text-lg py-2 px-6 mb-4 mx-auto w-fit">
+              <Badge 
+                className="text-lg py-2 px-6 mb-4 mx-auto w-fit text-white"
+                style={{ backgroundColor: 'var(--orange-9)' }}
+              >
                 🆓 完全無料
               </Badge>
               <CardTitle className="text-2xl">無料体験・相談会</CardTitle>
@@ -57,7 +60,7 @@ export default function PricingSection({ data }: PricingSectionProps) {
           {/* 物販商品 */}
           <Card className="shadow-2xl flex flex-col h-full">
             <CardHeader className="text-center pb-4">
-              <Badge className="bg-blue-500 hover:bg-blue-600 text-lg py-2 px-6 mb-4 mx-auto w-fit">
+              <Badge className="bg-[#6cb7c7] hover:bg-[#5aa3b5] text-lg py-2 px-6 mb-4 mx-auto w-fit">
                 🎁 物販商品ラインナップ
               </Badge>
               <CardTitle className="text-2xl">お持ち帰りキット</CardTitle>

--- a/src/components/sections/TeamSection.tsx
+++ b/src/components/sections/TeamSection.tsx
@@ -25,7 +25,7 @@ export default function TeamSection({ data }: TeamSectionProps) {
           ))}
         </div>
 
-        <Card className="mt-12 bg-gradient-to-r from-indigo-50 to-purple-50 border-indigo-200">
+        <Card className="mt-12 bg-gradient-to-r from-blue-50 to-cyan-50 border-blue-200">
           <CardContent className="p-8 text-center">
             <CardTitle className="text-2xl mb-4">
               {data.finalMessage.title}

--- a/src/data/sections/experience.ts
+++ b/src/data/sections/experience.ts
@@ -8,7 +8,7 @@ export const experienceData: ExperienceData = {
   お子さんが「かっこいい！」と夢中になります`,
   badge: {
     text: "📝 自由研究対応＆無料体験（15分）",
-    variant: "orange",
+    variant: "blue",
   },
   images: [
     {

--- a/src/data/sections/hero.ts
+++ b/src/data/sections/hero.ts
@@ -1,8 +1,8 @@
 import type { HeroData } from '../../types/sections/hero';
 
 export const heroData: HeroData = {
-  title: '🔰はじめよう！',
-  subtitle: 'プログラムの世界！🆓',
+  title: '親子でプログラム×',
+  subtitle: '光る動くおもちゃ作り！',
   description: '親子で夏休みの思い出作り',
   video: {
     localSrc: '/videos/public-relations.TS.mp4',

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -39,6 +39,8 @@
   --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
   --color-sidebar-border: var(--sidebar-border);
   --color-sidebar-ring: var(--sidebar-ring);
+  --color-orange-9: var(--orange-9);
+  --color-orange-10: var(--orange-10);
 }
 
 :root {
@@ -49,8 +51,8 @@
   --card-foreground: oklch(0.145 0 0);
   --popover: oklch(1 0 0);
   --popover-foreground: oklch(0.145 0 0);
-  --primary: oklch(0.205 0 0);
-  --primary-foreground: oklch(0.985 0 0);
+  --primary: oklch(0.83 0.08 200);
+  --primary-foreground: oklch(0.2 0 0);
   --secondary: oklch(0.97 0 0);
   --secondary-foreground: oklch(0.205 0 0);
   --muted: oklch(0.97 0 0);
@@ -61,14 +63,16 @@
   --border: oklch(0.922 0 0);
   --input: oklch(0.922 0 0);
   --ring: oklch(0.708 0 0);
-  --chart-1: oklch(0.646 0.222 41.116);
-  --chart-2: oklch(0.6 0.118 184.704);
-  --chart-3: oklch(0.398 0.07 227.392);
-  --chart-4: oklch(0.828 0.189 84.429);
-  --chart-5: oklch(0.769 0.188 70.08);
+  --chart-1: oklch(0.6 0.15 246);
+  --chart-2: oklch(0.65 0.12 220);
+  --chart-3: oklch(0.55 0.18 260);
+  --chart-4: oklch(0.7 0.14 200);
+  --chart-5: oklch(0.5 0.16 240);
+  --orange-9: oklch(0.755 0.138 44.29);
+  --orange-10: oklch(0.713 0.149 41.95);
   --sidebar: oklch(0.985 0 0);
   --sidebar-foreground: oklch(0.145 0 0);
-  --sidebar-primary: oklch(0.205 0 0);
+  --sidebar-primary: oklch(0.558 0.148 246.086);
   --sidebar-primary-foreground: oklch(0.985 0 0);
   --sidebar-accent: oklch(0.97 0 0);
   --sidebar-accent-foreground: oklch(0.205 0 0);
@@ -83,8 +87,8 @@
   --card-foreground: oklch(0.985 0 0);
   --popover: oklch(0.205 0 0);
   --popover-foreground: oklch(0.985 0 0);
-  --primary: oklch(0.922 0 0);
-  --primary-foreground: oklch(0.205 0 0);
+  --primary: oklch(0.8 0.1 200);
+  --primary-foreground: oklch(0.2 0 0);
   --secondary: oklch(0.269 0 0);
   --secondary-foreground: oklch(0.985 0 0);
   --muted: oklch(0.269 0 0);
@@ -95,14 +99,16 @@
   --border: oklch(1 0 0 / 10%);
   --input: oklch(1 0 0 / 15%);
   --ring: oklch(0.556 0 0);
-  --chart-1: oklch(0.488 0.243 264.376);
-  --chart-2: oklch(0.696 0.17 162.48);
-  --chart-3: oklch(0.769 0.188 70.08);
-  --chart-4: oklch(0.627 0.265 303.9);
-  --chart-5: oklch(0.645 0.246 16.439);
+  --chart-1: oklch(0.5 0.18 260);
+  --chart-2: oklch(0.6 0.14 230);
+  --chart-3: oklch(0.65 0.16 250);
+  --chart-4: oklch(0.55 0.12 220);
+  --chart-5: oklch(0.7 0.15 240);
+  --orange-9: oklch(0.755 0.138 44.29);
+  --orange-10: oklch(0.713 0.149 41.95);
   --sidebar: oklch(0.205 0 0);
   --sidebar-foreground: oklch(0.985 0 0);
-  --sidebar-primary: oklch(0.488 0.243 264.376);
+  --sidebar-primary: oklch(0.6 0.15 246);
   --sidebar-primary-foreground: oklch(0.985 0 0);
   --sidebar-accent: oklch(0.269 0 0);
   --sidebar-accent-foreground: oklch(0.985 0 0);


### PR DESCRIPTION
- ヒーローセクション：オレンジ系からブルー・シアン系のグラデーションに変更
- CTAボタン：CSS変数を使用したオレンジ色のアクセント
- チームメンバーカード：カラーパレットを調整（オレンジ→ブルー、イエロー→シアン）
- 各セクション：統一されたブルー・シアン系の背景とアクセント色
- グローバルCSS：オレンジ色のCSS変数とカラーテーマを追加
- 全体的なビジュアル一貫性とブランディングの強化

🤖 Generated with [Claude Code](https://claude.ai/code)